### PR TITLE
✨ chore: update CV URL in app constants file

### DIFF
--- a/lib/utils/app_constants.dart
+++ b/lib/utils/app_constants.dart
@@ -5,7 +5,7 @@ const String kProfileImageURL =
     'https://avatars.githubusercontent.com/u/53393418?v=4';
 
 const String kCvUrl =
-    'https://drive.google.com/file/d/1fiAvaNquixLzfm4ewlX_fKcM4QdlKB_v/view?usp=drive_link';
+    'https://drive.google.com/file/d/1t2wiqbtACsbAL-n-qW5dYurfkTmszm6o/view?usp=drive_link';
 
 const String kViewAllWorkLink = 'https://github.com/dhruvanbhalara';
 


### PR DESCRIPTION
Update the CV URL in the app constants to the new link for better 
accessibility. This change ensures that users can view the most 
current version of the CV.